### PR TITLE
Revert "Add instagram.com" as it's duplicated.

### DIFF
--- a/gfwlistplus.txt
+++ b/gfwlistplus.txt
@@ -1,5 +1,5 @@
 ! GFWList Plus 
-! Last Modified: Sat, 5 Oct 2014 00:17:52 +0800
+! Last Modified: Sat, 13 Sep 2014 12:04:02 +0800
 !----------------Restricted----------------
 ||aarki.net
 ||altrec.com
@@ -42,8 +42,6 @@ cdn.sstatic.net
 !--------------------HH--------------------
 
 !--------------------II--------------------
-|instagram.com
-|*instagram.com
 
 !--------------------JJ--------------------
 


### PR DESCRIPTION
There are same rules in `gfwlist.txt` now. :grinning: 
See https://code.google.com/p/autoproxy-gfwlist/issues/detail?id=161

This reverts commit https://github.com/Wllmw/GFWListPlus/commit/3477fb3f39ae85f9ce513f9d501044d103be27d8 .
